### PR TITLE
[Rust] 5章

### DIFF
--- a/rust/src/expr.rs
+++ b/rust/src/expr.rs
@@ -1,0 +1,110 @@
+// https://craftinginterpreters.com/representing-code.html
+
+use crate::token::{Token, TokenType};
+
+/// literal | unary | binary| grouping ;
+pub enum Expr {
+    // expression operator expression
+    Binary(Box<Expr>, TokenType, Box<Expr>),
+    // "(" expression ")" ;
+    Grouping(Box<Expr>),
+    // ( "-" | "!" ) expression ;
+    Unary(TokenType, Box<Expr>),
+    // NUMBER | STRING | "true" | "false" | "nil" ;
+    Literal(Literal),
+}
+
+#[derive(Debug)]
+pub enum Literal {
+    Number(f64),
+    String(String),
+    True,
+    False,
+    Nil,
+}
+
+trait Visitor {
+    fn visit_binary_expr(&mut self, left: &Box<Expr>, binary_op: &TokenType, right: &Box<Expr>);
+    fn visit_grouping_expr(&mut self, expr: &Expr);
+    fn visit_literal_expr(&mut self, literal: &Literal);
+    fn visit_unary_expr(&mut self, unary: &TokenType, expr: &Box<Expr>);
+}
+
+pub struct AstPrinter;
+
+impl AstPrinter {
+    pub fn print(&mut self, expr: &Expr) {
+        expr.accept(self)
+    }
+}
+
+impl Expr {
+    fn accept(&self, visitor: &mut dyn Visitor) {
+        match self {
+            Expr::Binary(left, binary_op, right) => {
+                visitor.visit_binary_expr(left, binary_op, right)
+            }
+            Expr::Grouping(expr) => visitor.visit_grouping_expr(expr),
+            Expr::Literal(literal) => visitor.visit_literal_expr(literal),
+            Expr::Unary(unary, expr) => visitor.visit_unary_expr(unary, expr),
+        }
+    }
+}
+
+impl Visitor for AstPrinter {
+    fn visit_binary_expr(&mut self, left: &Box<Expr>, binary_op: &TokenType, right: &Box<Expr>) {
+        print!("(");
+        left.accept(self);
+        match binary_op {
+            TokenType::Minus => print!("-"),
+            TokenType::Plus => print!("+"),
+            TokenType::Slash => print!("/"),
+            TokenType::Star => print!("*"),
+            _ => {}
+        }
+        right.accept(self);
+        print!(")");
+    }
+    fn visit_grouping_expr(&mut self, expr: &Expr) {
+        print!("(");
+        expr.accept(self);
+        print!(")");
+    }
+    fn visit_literal_expr(&mut self, literal: &Literal) {
+        match literal {
+            Literal::Number(n) => print!("{}", n),
+            Literal::String(s) => print!("{}", s),
+            Literal::True => print!("true"),
+            Literal::False => print!("false"),
+            Literal::Nil => print!("nil"),
+        }
+    }
+    fn visit_unary_expr(&mut self, unary: &TokenType, expr: &Box<Expr>) {
+        print!("(");
+        match unary {
+            TokenType::Minus => print!("-"),
+            TokenType::Bang => print!("!"),
+            _ => {}
+        }
+        expr.accept(self);
+        print!(")");
+    }
+}
+
+fn main() {
+    // -2 * (3 + 4)
+    let tokens = Expr::Binary(
+        Box::new(Expr::Unary(
+            TokenType::Minus,
+            Box::new(Expr::Literal(Literal::Number(2.0))),
+        )),
+        TokenType::Star,
+        Box::new(Expr::Grouping(Box::new(Expr::Binary(
+            Box::new(Expr::Literal(Literal::Number(3.0))),
+            TokenType::Plus,
+            Box::new(Expr::Literal(Literal::Number(4.0))),
+        )))),
+    );
+    let mut printer = AstPrinter;
+    printer.print(&tokens);
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,6 +1,7 @@
 // このコードでは crafting interpretersという本の内容を写経しています。
 // しかし、本ではサンプルコードがJavaで書かれているので、Rustで書き直しています。
 
+use expr::{AstPrinter, Expr, Literal};
 use scanner::Scanner;
 use std::cell::RefCell;
 use std::env;
@@ -9,7 +10,9 @@ use std::io::{self, BufRead, Write};
 use std::path::Path;
 use std::process;
 use std::rc::Rc;
+use token::TokenType;
 
+mod expr;
 mod scanner;
 mod token;
 


### PR DESCRIPTION

## [Representing Code](https://craftinginterpreters.com/representing-code.html)

Visitorパターン（オブジェクトの構造とその操作を分離する手法）を用いてASTを解析する。本章では`AstPrinter`を用いて構文の正しさをデバッグしている。

現状の`main()`関数では手動でASTを構築しているが、おそらく次の章あたりで構文解析器（Parser）をつくって、そこでここで作った諸々が役になってくるのではないかという予感。
