### PR TITLE
[Go] Chapter5実装

### DIFF
--- a/go/ast/expr.go
+++ b/go/ast/expr.go
@@ -1,0 +1,53 @@
+package ast
+
+import (
+	"github.com/AsazuTaiga/crafting_interpriters/go/token"
+)
+
+type Expr interface {
+	Accept(visitor Visitor) interface{}
+}
+
+type Visitor interface {
+	VisitBinaryExpr(expr BinaryExpr) interface{}
+	VisitGroupingExpr(expr GroupingExpr) interface{}
+	VisitLiteralExpr(expr LiteralExpr) interface{}
+	VisitUnaryExpr(expr UnaryExpr) interface{}
+}
+
+type BinaryExpr struct {
+	Left Expr
+	Operator token.Token
+	Right Expr
+}
+
+func (expr BinaryExpr) Accept(visitor Visitor) interface{} {
+	return visitor.VisitBinaryExpr(expr)
+}
+
+type GroupingExpr struct {
+	Expression Expr
+}
+
+func (expr GroupingExpr) Accept(visitor Visitor) interface{} {
+	return visitor.VisitGroupingExpr(expr)
+}
+
+type LiteralExpr struct {
+	Value interface{}
+}
+
+func (expr LiteralExpr) Accept(visitor Visitor) interface{} {
+	return visitor.VisitLiteralExpr(expr)
+}
+
+type UnaryExpr struct {
+	Operator token.Token
+	Right Expr
+}
+
+func (expr UnaryExpr) Accept(visitor Visitor) interface{} {
+	return visitor.VisitUnaryExpr(expr)
+}
+
+

--- a/go/cmd/ast_printer.go
+++ b/go/cmd/ast_printer.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"github.com/AsazuTaiga/crafting_interpriters/go/ast"
+	"github.com/AsazuTaiga/crafting_interpriters/go/token"
+)
+
+type AstPrinter struct {}
+
+func (p AstPrinter) Print(expr ast.Expr) string {
+	return expr.Accept(p).(string)
+}
+
+func (p AstPrinter) VisitBinaryExpr(expr ast.BinaryExpr) interface{} {
+	return p.parenthesize(expr.Operator.Lexeme, expr.Left, expr.Right)
+}
+
+func (p AstPrinter) VisitGroupingExpr(expr ast.GroupingExpr) interface{} {
+	return p.parenthesize("group", expr.Expression)
+}
+
+func (p AstPrinter) VisitLiteralExpr(expr ast.LiteralExpr) interface{} {
+	if expr.Value == nil {
+		return "nil"
+	}
+	return expr.Value.(string)
+}
+
+func (p AstPrinter) VisitUnaryExpr(expr ast.UnaryExpr) interface{} {
+	return p.parenthesize(expr.Operator.Lexeme, expr.Right)
+}
+
+func (p AstPrinter) parenthesize(name string, exprs ...ast.Expr) string {
+	str := "(" + name
+	for _, expr := range exprs {
+		str += " "
+		str += expr.Accept(p).(string)
+	}
+	str += ")"
+	return str
+}
+
+
+func main() {
+	expression := ast.BinaryExpr{
+		Left: &ast.UnaryExpr{
+			Operator: token.Token{
+				Type: token.MINUS,
+				Lexeme: "-",
+				Literal: nil,
+				Line: 1,
+			},
+			Right: &ast.LiteralExpr{
+				Value: "123",
+			},
+		},
+		Operator: token.Token{
+			Type: token.STAR,
+			Lexeme: "*",
+			Literal: nil,
+			Line: 1,
+		},
+		Right: &ast.GroupingExpr{
+			Expression: &ast.LiteralExpr{
+				Value: "45.67",
+			},
+		},
+	}
+
+	printer := AstPrinter{}
+	println(printer.Print(&expression))
+}

--- a/go/cmd/glox.go
+++ b/go/cmd/glox.go
@@ -5,10 +5,8 @@ import (
 	"github.com/AsazuTaiga/crafting_interpriters/go/lox"
 )
 
-func main() {
+func Run() {
 	log := logger.NewLogger()
 	l := lox.NewLox(log)
 	l.Run()
 }
-
-


### PR DESCRIPTION
##  [Representing code](https://craftinginterpreters.com/representing-code.html)


ボトムアップで作ってる
字句解析 -> AST構築
### 参考
[goでのvisitor pattern](https://refactoring.guru/ja/design-patterns/visitor/go/example)

### コメント
goのポインタ周りで詰まった

cmdツールが出てきてmain.goをmainパッケージとするのだとキツくなってきて、main.goからcmdパッケージを呼び出す形式にいずれ変える
今はcmdをmainパッケージとして直接呼び出してる。