### PR TITLE
[java] chapter 9 - Control Flow

### DIFF
--- a/java/.devcontainer/devcontainer.json
+++ b/java/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 			"installMaven": "false",
 			"installGradle": "false"
 		}
-	}
+	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
@@ -20,8 +20,16 @@
 	// "postCreateCommand": "java -version",
 
 	// Configure tool-specific properties.
-	// "customizations": {},
-
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"github.copilot.enable": {
+					"*": false, // Disable GitHub Copilot because this repo is for educational purposes
+				}
+			}
+		}
+	}
+	
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/java/dev/asazutaiga/lox/Expr.java
+++ b/java/dev/asazutaiga/lox/Expr.java
@@ -13,6 +13,8 @@ abstract class Expr {
 
     R visitLiteralExpr(Literal expr);
 
+    R visitLogicalExpr(Logical expr);
+
     R visitUnaryExpr(Unary expr);
 
     R visitVariableExpr(Variable expr);
@@ -75,6 +77,23 @@ abstract class Expr {
     }
 
     final Object value;
+  }
+
+  static class Logical extends Expr {
+    Logical(Expr left, Token operator, Expr right) {
+      this.left = left;
+      this.operator = operator;
+      this.right = right;
+    }
+
+    @Override
+    <R> R accept(Visitor<R> visitor) {
+      return visitor.visitLogicalExpr(this);
+    }
+
+    final Expr left;
+    final Token operator;
+    final Expr right;
   }
 
   static class Unary extends Expr {

--- a/java/dev/asazutaiga/lox/Interpreter.java
+++ b/java/dev/asazutaiga/lox/Interpreter.java
@@ -8,6 +8,7 @@ import dev.asazutaiga.lox.Expr.Unary;
 import dev.asazutaiga.lox.Expr.Variable;
 import dev.asazutaiga.lox.Stmt.Block;
 import dev.asazutaiga.lox.Stmt.Expression;
+import dev.asazutaiga.lox.Stmt.If;
 import dev.asazutaiga.lox.Stmt.Print;
 import dev.asazutaiga.lox.Stmt.Var;
 
@@ -155,6 +156,16 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
   @Override
   public Void visitExpressionStmt(Expression stmt) {
     evaluate(stmt.expression);
+    return null;
+  }
+
+  @Override
+  public Void visitIfStmt(If stmt) {
+    if (isTruthy(evaluate(stmt.condition))) {
+      execute(stmt.thenBranch);
+    } else if (stmt.elseBranch != null) {
+      execute(stmt.elseBranch);
+    }
     return null;
   }
 

--- a/java/dev/asazutaiga/lox/Interpreter.java
+++ b/java/dev/asazutaiga/lox/Interpreter.java
@@ -12,6 +12,7 @@ import dev.asazutaiga.lox.Stmt.Expression;
 import dev.asazutaiga.lox.Stmt.If;
 import dev.asazutaiga.lox.Stmt.Print;
 import dev.asazutaiga.lox.Stmt.Var;
+import dev.asazutaiga.lox.Stmt.While;
 
 import static dev.asazutaiga.lox.TokenType.*;
 
@@ -200,6 +201,14 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
     }
 
     environment.define(stmt.name.lexeme, value);
+    return null;
+  }
+
+  @Override
+  public Void visitWhileStmt(While stmt) {
+    while (isTruthy(evaluate(stmt.condition))) {
+      execute(stmt.body);
+    }
     return null;
   }
 

--- a/java/dev/asazutaiga/lox/Interpreter.java
+++ b/java/dev/asazutaiga/lox/Interpreter.java
@@ -4,6 +4,7 @@ import dev.asazutaiga.lox.Expr.Assign;
 import dev.asazutaiga.lox.Expr.Binary;
 import dev.asazutaiga.lox.Expr.Grouping;
 import dev.asazutaiga.lox.Expr.Literal;
+import dev.asazutaiga.lox.Expr.Logical;
 import dev.asazutaiga.lox.Expr.Unary;
 import dev.asazutaiga.lox.Expr.Variable;
 import dev.asazutaiga.lox.Stmt.Block;
@@ -27,6 +28,21 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
   @Override
   public Object visitLiteralExpr(Literal expr) {
     return expr.value;
+  }
+
+  @Override
+  public Object visitLogicalExpr(Logical expr) {
+    Object left = evaluate(expr.left);
+
+    if (expr.operator.type == TokenType.OR) {
+      if (isTruthy(left))
+        return left;
+    } else {
+      if (!isTruthy(left))
+        return left;
+    }
+
+    return evaluate(expr.right);
   }
 
   @Override
@@ -217,4 +233,5 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
       this.environment = previous;
     }
   }
+
 }

--- a/java/dev/asazutaiga/lox/Parser.java
+++ b/java/dev/asazutaiga/lox/Parser.java
@@ -70,12 +70,28 @@ class Parser {
   }
 
   private Stmt statement() {
+    if (match(IF))
+      return ifStatement();
     if (match(PRINT))
       return printStatement();
     if (match(LEFT_BRACE)) {
       return new Stmt.Block(block());
     }
     return expressionStatement();
+  }
+
+  private Stmt ifStatement() {
+    consume(LEFT_PAREN, "Expect '(' after 'if'.");
+    Expr condition = expression();
+    consume(RIGHT_PAREN, "Expect ')' after 'if'.");
+
+    Stmt thenBranch = statement();
+    Stmt elseBranch = null;
+    if (match(ELSE)) {
+      elseBranch = statement();
+    }
+
+    return new Stmt.If(condition, thenBranch, elseBranch);
   }
 
   private Stmt printStatement() {

--- a/java/dev/asazutaiga/lox/Parser.java
+++ b/java/dev/asazutaiga/lox/Parser.java
@@ -97,6 +97,8 @@ class Parser {
       return ifStatement();
     if (match(PRINT))
       return printStatement();
+    if (match(WHILE))
+      return whileStatement();
     if (match(LEFT_BRACE)) {
       return new Stmt.Block(block());
     }
@@ -121,6 +123,15 @@ class Parser {
     Expr value = expression();
     consume(SEMICOLON, "Expect ';' after value.");
     return new Stmt.Print(value);
+  }
+
+  private Stmt whileStatement() {
+    consume(LEFT_PAREN, "Expect '(' after 'while'.");
+    Expr condition = expression();
+    consume(RIGHT_PAREN, "Expect ')' after condition.");
+    Stmt body = statement();
+
+    return new Stmt.While(condition, body);
   }
 
   private Stmt expressionStatement() {

--- a/java/dev/asazutaiga/lox/Parser.java
+++ b/java/dev/asazutaiga/lox/Parser.java
@@ -52,7 +52,7 @@ class Parser {
   }
 
   private Expr assignment() {
-    Expr expr = equality();
+    Expr expr = or();
 
     if (match(EQUAL)) {
       Token equals = previous();
@@ -62,8 +62,31 @@ class Parser {
         Token name = ((Expr.Variable) expr).name;
         return new Expr.Assign(name, value);
       }
-
       error(equals, "Invalid assignment target.");
+    }
+
+    return expr;
+  }
+
+  private Expr or() {
+    Expr expr = and();
+
+    while (match(OR)) {
+      Token operator = previous();
+      Expr right = and();
+      expr = new Expr.Logical(expr, operator, right);
+    }
+
+    return expr;
+  }
+
+  private Expr and() {
+    Expr expr = equality();
+
+    while (match(AND)) {
+      Token operator = previous();
+      Expr right = equality();
+      expr = new Expr.Logical(expr, operator, right);
     }
 
     return expr;

--- a/java/dev/asazutaiga/lox/Stmt.java
+++ b/java/dev/asazutaiga/lox/Stmt.java
@@ -15,6 +15,8 @@ abstract class Stmt {
 
     R visitVarStmt(Var stmt);
 
+    R visitWhileStmt(While stmt);
+
   }
 
   static class Block extends Stmt {
@@ -86,6 +88,21 @@ abstract class Stmt {
 
     final Token name;
     final Expr initializer;
+  }
+
+  static class While extends Stmt {
+    While(Expr condition, Stmt body) {
+      this.condition = condition;
+      this.body = body;
+    }
+
+    @Override
+    <R> R accept(Visitor<R> visitor) {
+      return visitor.visitWhileStmt(this);
+    }
+
+    final Expr condition;
+    final Stmt body;
   }
 
   abstract <R> R accept(Visitor<R> visitor);

--- a/java/dev/asazutaiga/lox/Stmt.java
+++ b/java/dev/asazutaiga/lox/Stmt.java
@@ -9,6 +9,8 @@ abstract class Stmt {
 
     R visitExpressionStmt(Expression stmt);
 
+    R visitIfStmt(If stmt);
+
     R visitPrintStmt(Print stmt);
 
     R visitVarStmt(Var stmt);
@@ -39,6 +41,23 @@ abstract class Stmt {
     }
 
     final Expr expression;
+  }
+
+  static class If extends Stmt {
+    If(Expr condition, Stmt thenBranch, Stmt elseBranch) {
+      this.condition = condition;
+      this.thenBranch = thenBranch;
+      this.elseBranch = elseBranch;
+    }
+
+    @Override
+    <R> R accept(Visitor<R> visitor) {
+      return visitor.visitIfStmt(this);
+    }
+
+    final Expr condition;
+    final Stmt thenBranch;
+    final Stmt elseBranch;
   }
 
   static class Print extends Stmt {

--- a/java/dev/asazutaiga/tool/GenerateAst.java
+++ b/java/dev/asazutaiga/tool/GenerateAst.java
@@ -17,6 +17,7 @@ public class GenerateAst {
         "Binary   : Expr left, Token operator, Expr right",
         "Grouping : Expr expression",
         "Literal  : Object value",
+        "Logical  : Expr left, Token operator, Expr right",
         "Unary    : Token operator, Expr right",
         "Variable : Token name"));
 

--- a/java/dev/asazutaiga/tool/GenerateAst.java
+++ b/java/dev/asazutaiga/tool/GenerateAst.java
@@ -23,6 +23,7 @@ public class GenerateAst {
     defineAst(outputDir, "Stmt", Arrays.asList(
         "Block      : List<Stmt> statements",
         "Expression : Expr expression",
+        "If         : Expr condition, Stmt thenBranch, Stmt elseBranch",
         "Print      : Expr expression",
         "Var        : Token name, Expr initializer"));
   }

--- a/java/dev/asazutaiga/tool/GenerateAst.java
+++ b/java/dev/asazutaiga/tool/GenerateAst.java
@@ -26,7 +26,8 @@ public class GenerateAst {
         "Expression : Expr expression",
         "If         : Expr condition, Stmt thenBranch, Stmt elseBranch",
         "Print      : Expr expression",
-        "Var        : Token name, Expr initializer"));
+        "Var        : Token name, Expr initializer",
+        "While      : Expr condition, Stmt body"));
   }
 
   private static void defineAst(

--- a/java/makefile
+++ b/java/makefile
@@ -1,4 +1,4 @@
-ARG = ./test/test5.lox
+ARG = ./test/test6.lox
 
 all: 
 	javac dev/asazutaiga/lox/Lox.java

--- a/java/makefile
+++ b/java/makefile
@@ -1,4 +1,4 @@
-ARG = ./test/test6.lox
+ARG = ./test/test7.lox
 
 all: 
 	javac dev/asazutaiga/lox/Lox.java

--- a/java/notes/9_Control_Flow.md
+++ b/java/notes/9_Control_Flow.md
@@ -76,3 +76,43 @@
     - `return new Stmt.While(condition, body)` する
 - Interpreter.javaに以下を追加
   - `visitWhileStmt(Stmt.While stmt)` で、Javaのwhile文をそのまま使って、条件がtruthyであるかどうか評価し、その場合には本文を実行
+
+## For ループ
+- `for (var i = 0; i < 10; i = i + 1) print i;` みたいな感じ
+- BNF
+  ```
+  statement   -> exprStmt
+               | forStmt
+               | ifStmt
+               | printStmt
+               | whileStmt
+               | block ;
+  forStmt     -> "for" "(" ( varDecl | exprStmt | ";" )
+                 expression? ";"
+                 expression? ")" statement ;
+  ```
+- カッコの中にセミコロンで分割された三つの句がある
+  1. initializer
+     - 一度だけ実行される
+     - 通常は式だが、便宜上変数宣言も許可する。その場合、変数のスコープはforループの残りの部分（他の2つの句と本体）になる
+  2. condition
+     - ループを終了するタイミングを制御する
+     - 各反復の開始時に1回評価される
+     - 結果が真の場合、ループ本体が実行される  
+  3. increment
+     - 各ループ反復の最後になんらかの処理を実行する任意の式
+     - 式の結果は破棄されるため、有用であるためには副作用が必要
+     - 通常は変数をインクリメントする
+- これらの句はいずれも省略できる
+- Loxには上記の機能はいずれも存在するので、forは必要ない
+  - **糖衣構文**である
+- **desugaring**（脱糖？）処理をすることで、forループを変数宣言+whileループとして処理する方針でいく
+  - なので、Ast上には`forStmt`のようなものは登場しない
+- Parser.javaに以下を追加する
+  - `statement()`
+    - `for`にマッチしたら`forStatement()`に分岐
+  - `forStatement()`
+    - `initializer`, `condition`, `increment`, `body` をそれぞれ読み取る
+    - 逆順 (`incremnt`, `condition`, `initializer`)の順にdesugarしていく（その方がシンプルになるらしい）
+      - 書いてみてわかったが実際そう。（`body`変数の使い方な気もするが）
+- テストを追加

--- a/java/notes/9_Control_Flow.md
+++ b/java/notes/9_Control_Flow.md
@@ -31,4 +31,23 @@
 - Interpreterに処理を追加する
 
 ## 論理演算子
-- 
+- `and`, `or` を作る
+  - これらは短絡評価である点で、他の２項演算子と異なる
+  - `false and sideEffect();` みたいな例では右側を評価しないよね
+- BNF
+  ```
+  expression  -> assignment ;
+  assingment  -> IDENTIFIER "=" assignment
+               | logic_or ;
+  logic_or    -> logic_and ( "or" logic_and )* ;
+  logic_and   -> equality ( "and" equality )* ;
+  ```
+  - `assignment` と `equality` の間に `and`, `or` が来る
+- `and`, `or`を表すために`Expr.Binary` クラスを再利用する？（フィールドが同じなため）
+  - 再利用しない
+  - `visitBinaryExpr()`で論理演算子かどうかチェックして短絡評価のハンドリングに分岐する必要があると考えると、クラスを分けてそれぞれのvisitメソッドを作った方がよい
+- GenerateAstに追記して生成、Parserに処理を追加する
+- Interpreterに処理を追加する
+  - 短絡評価になっていることに注意せよ
+    - `visitBinaryExpr` と `visitLogicalOperator` を比較するとよりよくわかる
+    - 前者がとりあえず左辺と右辺を`evaluate`して、演算子の種別ごとに評価しているのに対し、後者は `evaluate(expr.right)` をぎりぎりまで呼ばないようにしてる

--- a/java/notes/9_Control_Flow.md
+++ b/java/notes/9_Control_Flow.md
@@ -51,3 +51,28 @@
   - 短絡評価になっていることに注意せよ
     - `visitBinaryExpr` と `visitLogicalOperator` を比較するとよりよくわかる
     - 前者がとりあえず左辺と右辺を`evaluate`して、演算子の種別ごとに評価しているのに対し、後者は `evaluate(expr.right)` をぎりぎりまで呼ばないようにしてる
+  
+## While ループ
+- for ループより簡単らしい（それはそう）
+- BNF
+  ```
+  statement  -> exprStmt
+              | ifStmt
+              | printStmt
+              | whileStmt
+              | block ;
+  whileStmt  -> "while" "(" expression ")" statement ;
+  ```
+- ルールをGenerateAst.javaに追加する
+- > ここで、式と文に個別の基本クラスを用意することがなぜ良いのかがわかります。フィールド宣言により、条件が式であり本文が文であることが明確になります。
+  - まあそれはそうだが、それはそうだろという感じ（個別の基本クラスを用意しないわけないだろと思っていたので）
+- Parser.javaに以下を追加
+  - 先頭のキーワード `while` を検出して判定し、`whileStatement()`に分岐させる
+  - `whileStatement()` で以下の順にトークンを消費
+    - `(`
+    - `expression()` で条件を取り出す
+    - `)`
+    - `statement()` で本文を取り出す
+    - `return new Stmt.While(condition, body)` する
+- Interpreter.javaに以下を追加
+  - `visitWhileStmt(Stmt.While stmt)` で、Javaのwhile文をそのまま使って、条件がtruthyであるかどうか評価し、その場合には本文を実行

--- a/java/notes/9_Control_Flow.md
+++ b/java/notes/9_Control_Flow.md
@@ -1,0 +1,34 @@
+# 9. Control Flow
+
+- if, 論理演算子, while, forの制御構文を実装していくチャプター
+- チューリングマシンについての概要
+  - チューリングマシンとラムダ計算
+  - > 必要なのは、関数をチューリング マシンに変換し、それをシミュレーターで実行することだけです。
+
+## if
+
+- if文の定義が文の定義に追加される
+  - ifはelseを伴ったり伴わなかったりする
+  ```
+  statement     -> exprStmt
+                  | ifStmt
+                  | printStmt
+                  | block ;
+  ifStmt        -> "if" "(" expression ")" statement
+                  ( "else" statement )? ;
+  ```
+- GenerateAstに定義を追加して、`class If extends Stmt`をつくる
+- Parserに処理を追加する
+  - `"if"` にマッチしたら `ifStatement` を呼び出す
+  - `condition` を取り出す
+  - `thenBranch` を取り出す
+  - `elseBranch` を取り出す 当然 `null` になることもある
+  - `new Stmt.If` する
+- ダングリング else 問題
+  - `if (first) if (second) whenTrue(); else whenFalse();` のelseは最初のif条件に対するものか、二番目に対するものか？
+    - Loxの場合はelseにもっとも近いifに束縛される
+      - というか再帰下降パーサーはだいたいそうなる
+- Interpreterに処理を追加する
+
+## 論理演算子
+- 

--- a/java/test/test6.lox
+++ b/java/test/test6.lox
@@ -1,0 +1,2 @@
+print "hi" or 2; // "hi".
+print nil or "yes"; // "yes".

--- a/java/test/test6.lox
+++ b/java/test/test6.lox
@@ -1,2 +1,9 @@
 print "hi" or 2; // "hi".
 print nil or "yes"; // "yes".
+{
+  var i = 0;
+  while (i < 10) {
+    print i;
+    i = i + 1;
+  }
+}

--- a/java/test/test7.lox
+++ b/java/test/test7.lox
@@ -1,0 +1,8 @@
+var a = 0;
+var temp;
+
+for (var b = 1; a < 10000; b = temp + b) {
+  print a;
+  temp = a;
+  a = b;
+}


### PR DESCRIPTION
今回から読書＆作業メモをとってる

# 9. Control Flow

- if, 論理演算子, while, forの制御構文を実装していくチャプター
- チューリングマシンについての概要
  - チューリングマシンとラムダ計算
  - > 必要なのは、関数をチューリング マシンに変換し、それをシミュレーターで実行することだけです。
## if

- if文の定義が文の定義に追加される
  - ifはelseを伴ったり伴わなかったりする
  ```
  statement     -> exprStmt
                  | ifStmt
                  | printStmt
                  | block ;
  ifStmt        -> "if" "(" expression ")" statement
                  ( "else" statement )? ;
  ```
- GenerateAstに定義を追加して、`class If extends Stmt`をつくる
- Parserに処理を追加する
  - `"if"` にマッチしたら `ifStatement` を呼び出す
  - `condition` を取り出す
  - `thenBranch` を取り出す
  - `elseBranch` を取り出す 当然 `null` になることもある
  - `new Stmt.If` する
- ダングリング else 問題
  - `if (first) if (second) whenTrue(); else whenFalse();` のelseは最初のif条件に対するものか、二番目に対するものか？
    - Loxの場合はelseにもっとも近いifに束縛される
      - というか再帰下降パーサーはだいたいそうなる
- Interpreterに処理を追加する

## 論理演算子
- `and`, `or` を作る
  - これらは短絡評価である点で、他の２項演算子と異なる
  - `false and sideEffect();` みたいな例では右側を評価しないよね
- BNF
  ```
  expression  -> assignment ;
  assingment  -> IDENTIFIER "=" assignment
               | logic_or ;
  logic_or    -> logic_and ( "or" logic_and )* ;
  logic_and   -> equality ( "and" equality )* ;
  ```
  - `assignment` と `equality` の間に `and`, `or` が来る
- `and`, `or`を表すために`Expr.Binary` クラスを再利用する？（フィールドが同じなため）
  - 再利用しない
  - `visitBinaryExpr()`で論理演算子かどうかチェックして短絡評価のハンドリングに分岐する必要があると考えると、クラスを分けてそれぞれのvisitメソッドを作った方がよい
- GenerateAstに追記して生成、Parserに処理を追加する
- Interpreterに処理を追加する
  - 短絡評価になっていることに注意せよ
    - `visitBinaryExpr` と `visitLogicalOperator` を比較するとよりよくわかる
    - 前者がとりあえず左辺と右辺を`evaluate`して、演算子の種別ごとに評価しているのに対し、後者は `evaluate(expr.right)` をぎりぎりまで呼ばないようにしてる

## While ループ
- for ループより簡単らしい（それはそう）
- BNF
  ```
  statement  -> exprStmt
              | ifStmt
              | printStmt
              | whileStmt
              | block ;
  whileStmt  -> "while" "(" expression ")" statement ;
  ```
- ルールをGenerateAst.javaに追加する
- > ここで、式と文に個別の基本クラスを用意することがなぜ良いのかがわかります。フィールド宣言により、条件が式であり本文が文であることが明確になります。
  - まあそれはそうだが、それはそうだろという感じ（個別の基本クラスを用意しないわけないだろと思っていたので）
- Parser.javaに以下を追加
  - 先頭のキーワード `while` を検出して判定し、`whileStatement()`に分岐させる
  - `whileStatement()` で以下の順にトークンを消費
    - `(`
    - `expression()` で条件を取り出す
    - `)`
    - `statement()` で本文を取り出す
    - `return new Stmt.While(condition, body)` する
- Interpreter.javaに以下を追加
  - `visitWhileStmt(Stmt.While stmt)` で、Javaのwhile文をそのまま使って、条件がtruthyであるかどうか評価し、その場合には本文を実行

## For ループ
- `for (var i = 0; i < 10; i = i + 1) print i;` みたいな感じ
- BNF
  ```
  statement   -> exprStmt
               | forStmt
               | ifStmt
               | printStmt
               | whileStmt
               | block ;
  forStmt     -> "for" "(" ( varDecl | exprStmt | ";" )
                 expression? ";"
                 expression? ")" statement ;
  ```
- カッコの中にセミコロンで分割された三つの句がある
  1. initializer
     - 一度だけ実行される
     - 通常は式だが、便宜上変数宣言も許可する。その場合、変数のスコープはforループの残りの部分（他の2つの句と本体）になる
  2. condition
     - ループを終了するタイミングを制御する
     - 各反復の開始時に1回評価される
     - 結果が真の場合、ループ本体が実行される  
  3. increment
     - 各ループ反復の最後になんらかの処理を実行する任意の式
     - 式の結果は破棄されるため、有用であるためには副作用が必要
     - 通常は変数をインクリメントする
- これらの句はいずれも省略できる
- Loxには上記の機能はいずれも存在するので、forは必要ない
  - **糖衣構文**である
- **desugaring**（脱糖？）処理をすることで、forループを変数宣言+whileループとして処理する方針でいく
  - なので、Ast上には`forStmt`のようなものは登場しない
- Parser.javaに以下を追加する
  - `statement()`
    - `for`にマッチしたら`forStatement()`に分岐
  - `forStatement()`
    - `initializer`, `condition`, `increment`, `body` をそれぞれ読み取る
    - 逆順 (`incremnt`, `condition`, `initializer`)の順にdesugarしていく（その方がシンプルになるらしい）
      - 書いてみてわかったが実際そう。（`body`変数の使い方な気もするが）
- テストを追加